### PR TITLE
remove 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' in xxx_xcconfig

### DIFF
--- a/WoodPeckeriOS.podspec
+++ b/WoodPeckeriOS.podspec
@@ -10,7 +10,4 @@ Pod::Spec.new do |s|
   s.source                      = { :git => "https://github.com/appwoodpecker/woodpecker-ios.git", :tag => "#{s.version}" }
   s.vendored_frameworks         = "WoodPeckeriOS.xcframework"
   s.license                     = { :type => 'Copyright', :file => 'LICENSE' }
-  s.user_target_xcconfig        = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.pod_target_xcconfig 		= { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
 end


### PR DESCRIPTION
use `pod lib lint --skip-import-validation`
remove 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' in xxx_xcconfig，Because it will contaminate the project configuration file.